### PR TITLE
Add Lambda authorizer and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+Copyright (c) 2026 A. Ramiso. All Rights Reserved.
+
+This source code is provided for viewing purposes only. No permission is granted
+to use, copy, modify, merge, publish, distribute, sublicense, or sell copies of
+this software, in whole or in part, without prior written permission from the
+copyright holder.
+
+For inquiries, contact the repository owner.

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -14,13 +14,13 @@ npx nodemon \
   --signal SIGTERM \
   --exec "bash scripts/sam-start.sh" &
 
-npx wait-on tcp:3000 -q 2>/dev/null
+npx wait-on tcp:3001 -q 2>/dev/null
 
-ngrok http 3000 --log stdout --log-format logfmt 2>&1 | while read line; do
+ngrok http 3001 --log stdout --log-format logfmt 2>&1 | while read line; do
   if echo "$line" | grep -q "url=https://"; then
     NGROK_URL=$(echo "$line" | grep -oP 'url=\K\S+')
     echo ""
-    echo "Local:  http://127.0.0.1:3000"
+    echo "Local:  http://127.0.0.1:3001"
     echo "Public: $NGROK_URL"
     echo ""
     echo "Ready."

--- a/scripts/sam-start.sh
+++ b/scripts/sam-start.sh
@@ -12,7 +12,7 @@ fi
 echo "Starting API..."
 CURRENT_LAMBDA=""
 LOG_COLOR=""
-sam local start-api --warm-containers EAGER 2>&1 | while IFS= read -r line; do
+sam local start-api --port 3001 --warm-containers EAGER 2>&1 | while IFS= read -r line; do
   if echo "$line" | grep -q "Running on"; then
     echo "$line"
     echo "Ready."


### PR DESCRIPTION
## Summary
- Add Supabase JWT Lambda authorizer with TokenAuthorizer in CDK
- Add Gateway Responses for uniform 401/403 error format
- Fix cyclic dependency by moving authorizer Lambda to ApiStack
- Add All Rights Reserved license

## Test plan
- [x] Authorizer triggers on protected routes
- [x] Expired/invalid tokens return proper error
- [x] Public routes (login, signup) skip authorizer
- [x] Verify Gateway Responses on AWS deploy